### PR TITLE
Use graph-based community detection for clustered inference

### DIFF
--- a/building_shape_params.yaml
+++ b/building_shape_params.yaml
@@ -1,10 +1,9 @@
 clustering:
-  algorithm: auto  # auto -> пытается hdbscan, затем DBSCAN из sklearn
-  min_cluster_size: 8
-  min_samples: 5
-  dbscan:
-    eps: 35.0
-    min_samples: 5
+  min_cluster_size: 8       # Минимальный размер сообщества, которое считаем кластером
+  knn_k: 8                  # Число соседей в kNN-графе (0 — отключить kNN-рёбра)
+  use_gabriel: true         # Строить ли дополнительно рёбра Габриелевой графы
+  community_algorithm: greedy  # greedy | label_propagation
+  min_samples: 5            # Legacy: используется как значение по умолчанию для knn_k
 
 geometry:
   round_ratio_max: 1.5      # Отношение длин сторон min_rotated_rectangle для «круглых» кластеров


### PR DESCRIPTION
## Summary
- replace the HDBSCAN/DBSCAN clustering pipeline with a graph-based approach that builds Gabriel and kNN edges and detects communities via NetworkX
- allow configuring the graph construction and community detection parameters through the clustering YAML options

## Testing
- python -m compileall batch_infer_blocks_clustered.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc255de888331a27596702438d66b