### PR TITLE
Fix missing zone parameter in clustered batch inference

### DIFF
--- a/batch_infer_blocks_clustered.py
+++ b/batch_infer_blocks_clustered.py
@@ -274,6 +274,7 @@ def main():
             "--infer-il-thr", str(args.infer_il_thr),
             "--infer-sv1-thr", str(args.infer_sv1_thr),
             "--infer-slots", str(infer_slots),
+            "--zone", str(zone_label),
         ]
         if args.config:
             cmd.extend(["--config", args.config])


### PR DESCRIPTION
## Summary
- ensure `batch_infer_blocks_clustered.py` always forwards the detected zone label to the underlying train script so zone-specific configs load correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de75d9dc088331aa08f0b72d6d9cf4